### PR TITLE
Fix: iOS 모임입장 스크린 조정 버그 수정 [iOS Only]

### DIFF
--- a/modules/app/navigation/config.tsx
+++ b/modules/app/navigation/config.tsx
@@ -34,6 +34,7 @@ export const options: {
     tabBarLabel: createTabBarLabel('모임 입장'),
     tabBarIcon: createTabBarIcon('meeting-room'),
     tabBarHideOnKeyboard: false,
+    freezeOnBlur: false,
   },
   [Tab.three]: {
     tabBarLabel: createTabBarLabel('마이페이지'),


### PR DESCRIPTION
버그 발생 조건: 마이페이지 닉네임 클릭하여 키보드 활성화후 모입 입장 스크린 렌더링시  `behavior={Platform.select({ ios: 'padding' })}` 키보드가 활성화 되지않았음에도 동작이되는 버그 발생

-> 모임 입장 네비게이션 속성 `freezeOnBlur: false` 속성 지정으로 이슈 수정